### PR TITLE
Update unidirectional-relations.ts, add await

### DIFF
--- a/packages/core/core/src/services/document-service/utils/unidirectional-relations.ts
+++ b/packages/core/core/src/services/document-service/utils/unidirectional-relations.ts
@@ -86,7 +86,7 @@ const sync = async (
   );
 
   await strapi.db.transaction(async ({ trx }) => {
-    const con = strapi.db.getConnection();
+    const con = await strapi.db.getConnection();
 
     // Iterate old relations that are deleted and insert the new ones
     for (const { joinTable, relations } of oldRelations) {


### PR DESCRIPTION
Fixing bug "con.batchInsert is not a function"

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Added await to strapi.db.getConnection()

<img width="399" alt="image" src="https://github.com/user-attachments/assets/1d138d0d-8441-4930-b974-28926d260364">


### Why is it needed?

On trying to Publish an entry with a unidirectional relationship, internal server error:
```
TypeError: con.batchInsert is not a function
    at /Users/remed.io/Sites/2024/remedio/server/node_modules/@strapi/core/dist/services/document-service/utils/unidirectional-relations.js:53:23
```

### How to test it?

Error fixed in CLI. Subsequent error, but this one is fixed.


